### PR TITLE
Event with namespace support.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,5 +2,6 @@
   "presets": [
     "es2015",
     "stage-0"
-  ]
+  ],
+  "plugins": ["transform-function-bind"]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@
     "plugins": [
         "import"
     ],
+    "parser": "babel-eslint",
     "rules": {
         "arrow-parens": ["error", "as-needed", { "requireForBlockBody": false }],
         "consistent-return": ["off"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
         "no-else-return": ["off"],
         "no-param-reassign": ["off"],
         "no-restricted-syntax": ["off"],
-        "no-underscore-dangle": ["off", { "allowAfterThis": true, "allowAfterSuper": true }]
+        "no-underscore-dangle": ["off", { "allowAfterThis": true, "allowAfterSuper": true }],
+        "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }]
     }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
   "devDependencies": {
     "ava": "^0.18.2",
     "babel-cli": "^6.24.0",
+    "babel-eslint": "^7.2.1",
+    "babel-plugin-transform-function-bind": "^6.22.0",
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-stage-0": "^6.22.0",
     "babel-register": "^6.24.0",
@@ -43,5 +45,9 @@
     "eslint-config-airbnb-base": "^11.1.2",
     "eslint-plugin-import": "^2.2.0",
     "eslint-watch": "^3.0.1"
+  },
+  "dependencies": {
+    "eventemitter2": "^4.1.0",
+    "rxjs": "^5.3.0"
   }
 }

--- a/src/state.js
+++ b/src/state.js
@@ -52,7 +52,7 @@ export default class State {
       return this.cursor(subPath).set(value);
     }
     this.__store.write(this.__cursor, value);
-    this.__emitter.emit(['change', ...this.__cursor], value);
+    this.__emitter.emit(['change', ...this.__cursor, '**'].join('.'), value);
   }
 
   currentCursor() {

--- a/src/state.js
+++ b/src/state.js
@@ -1,19 +1,33 @@
+import { EventEmitter2 } from 'eventemitter2';
+import { Observable } from 'rxjs/Observable';
+import { fromEvent } from 'rxjs/observable/fromEvent';
 import Store from './store';
 import { normalizePath } from './utils';
 
 export default class State {
 
-  constructor({ store = new Store(), cursor = [] } = {}) {
+  constructor({
+    store = new Store(),
+    cursor = [],
+    emitter = new EventEmitter2({
+      wildcard: true,
+      delimiter: '.',
+      // FIXME: is it good?
+      maxListeners: Infinity,
+    }),
+  } = {}) {
     this.__store = store;
     this.__cursor = cursor;
+    this.__emitter = emitter;
   }
 
   cursor(subPath = '') {
-    const { __store, __cursor } = this;
+    const { __store, __cursor, __emitter } = this;
     subPath = normalizePath(subPath);
     return new State({
       store: __store,
       cursor: __cursor.concat(subPath),
+      emitter: __emitter,
     });
   }
 
@@ -38,5 +52,23 @@ export default class State {
       return this.cursor(subPath).set(value);
     }
     this.__store.write(this.__cursor, value);
+    this.__emitter.emit(['change', ...this.__cursor], value);
+  }
+
+  currentCursor() {
+    return this.__cursor.join('.');
+  }
+
+  listen(message) {
+    let generatedMessage;
+    switch (message) {
+      case 'change':
+        generatedMessage = ['change', ...this.__cursor, '**'].join('.');
+        break;
+      default:
+        generatedMessage = message;
+        break;
+    }
+    return Observable::fromEvent(this.__emitter, generatedMessage);
   }
 }

--- a/src/state.js
+++ b/src/state.js
@@ -21,7 +21,7 @@ export default class State {
     this.__emitter = emitter;
   }
 
-  cursor(subPath = '') {
+  cursor(subPath = []) {
     const { __store, __cursor, __emitter } = this;
     subPath = normalizePath(subPath);
     return new State({
@@ -31,7 +31,7 @@ export default class State {
     });
   }
 
-  get(subPath = '') {
+  get(subPath = []) {
     const { length } = arguments;
     if (length !== 0) {
       return this.cursor(subPath).get();
@@ -52,14 +52,14 @@ export default class State {
       return this.cursor(subPath).set(value);
     }
     this.__store.write(this.__cursor, value);
-    this.__emitter.emit(['change', ...this.__cursor, '**'].join('.'), value);
+    this.__emitter.emit(['change', ...this.__cursor, '**'], value);
   }
 
   listen(message) {
     let generatedMessage;
     switch (message) {
       case 'change':
-        generatedMessage = ['change', ...this.__cursor, '**'].join('.');
+        generatedMessage = ['change', ...this.__cursor, '**'];
         break;
       default:
         generatedMessage = message;

--- a/src/state.js
+++ b/src/state.js
@@ -55,10 +55,6 @@ export default class State {
     this.__emitter.emit(['change', ...this.__cursor, '**'].join('.'), value);
   }
 
-  currentCursor() {
-    return this.__cursor.join('.');
-  }
-
   listen(message) {
     let generatedMessage;
     switch (message) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,7 +13,8 @@ export const hasNoProperties = obj => obj === undefined || obj === null;
 
 export const getByPath = (obj, path) => {
   let pointer = obj;
-  for (const next of path) {
+  for (let i = 0; i < path.length; i++) {
+    const next = path[i];
     if (hasNoProperties(pointer)) {
       return undefined;
     }
@@ -49,7 +50,8 @@ export const setByPath = (obj = {}, path = [], value) => {
   let lastNext = first;
   let pointer = hasNoProperties(obj) ? null : obj[first];
 
-  for (const next of rest) {
+  for (let i = 0; i < rest.length; i++) {
+    const next = rest[i];
     parentPointer[lastNext] = shallowClone(pointer, next);
     parentPointer = parentPointer[lastNext];
     lastNext = next;

--- a/test/state.js
+++ b/test/state.js
@@ -79,3 +79,41 @@ test('event emit with cursor', t => {
     .map(() => t.pass())
     .timeoutWith(OBSERVABLE_TIMEOUT, Observable.empty());
 });
+
+test('set path with dot', t => {
+  t.plan(5);
+  const state = new State();
+  process.nextTick(() => {
+    // should emit
+    state.set('', 1);
+    state.set('a', 1);
+    state.set('a.b', 1);
+    state.cursor('a').set('c', 1);
+    state.set(['a', 'b.c'], 1);
+    // should not emit
+    state.set(['a.d'], 1);
+    state.set(['a.e', 'f'], 1);
+  });
+  return Observable
+    .from(state.cursor('a').listen('change'))
+    .map(() => t.pass())
+    .timeoutWith(OBSERVABLE_TIMEOUT, Observable.empty());
+});
+
+test('listen path with dot', t => {
+  t.plan(3);
+  const state = new State();
+  process.nextTick(() => {
+    // should emit
+    state.set('', 1);
+    state.set(['a.b'], 1);
+    state.set(['a.b', 'c'], 1);
+    // should not emit
+    state.set('a', 1);
+    state.set('a.b', 1);
+  });
+  return Observable
+    .from(state.cursor(['a.b']).listen('change'))
+    .map(() => t.pass())
+    .timeoutWith(OBSERVABLE_TIMEOUT, Observable.empty());
+});

--- a/test/state.js
+++ b/test/state.js
@@ -70,9 +70,9 @@ test('event emit with cursor', t => {
     // should emit
     state.set('', 1);
     state.set('a', 1);
+    state.set('a.b', 1);
     state.cursor('a').set('c', 1);
     // should not emit
-    state.set('a.b', 1);
     state.set('c.d', 1);
   });
   return Observable

--- a/test/state.js
+++ b/test/state.js
@@ -54,7 +54,6 @@ test('event emit', t => {
     state.set('', 1);
     state.set('a', 1);
     state.set('a.b', 1);
-    // should not emit
     state.set('c.d', 1);
   });
   return Observable

--- a/test/state.js
+++ b/test/state.js
@@ -1,5 +1,8 @@
 import test from 'ava';
+import { Observable } from 'rxjs/Rx';
 import State from '../src/state';
+
+const OBSERVABLE_TIMEOUT = 100;
 
 test('get and set', t => {
   const state = new State();
@@ -41,4 +44,34 @@ test('cursor set', t => {
   cursorState.set({ c: { d: 1 } });
   cursorState.set('c.e', 2);
   t.deepEqual(state.get(), { a: { b: { c: { d: 1, e: 2 } } } });
+});
+
+test('event emit', t => {
+  t.plan(4);
+  const state = new State();
+  process.nextTick(() => {
+    state.set('', 1);
+    state.set('a', 1);
+    state.set('a.b', 1);
+    state.set('c.d', 1);
+  });
+  return Observable
+    .from(state.listen('change'))
+    .map(() => t.pass())
+    .timeoutWith(OBSERVABLE_TIMEOUT, Observable.empty());
+});
+
+test('event emit with cursor', t => {
+  t.plan(3);
+  const state = new State();
+  process.nextTick(() => {
+    state.set('', 1);
+    state.set('a', 1);
+    state.set('a.b', 1);
+    state.set('c.d', 1);
+  });
+  return Observable
+    .from(state.cursor('a').listen('change'))
+    .map(() => t.pass())
+    .timeoutWith(OBSERVABLE_TIMEOUT, Observable.empty());
 });

--- a/test/state.js
+++ b/test/state.js
@@ -50,9 +50,11 @@ test('event emit', t => {
   t.plan(4);
   const state = new State();
   process.nextTick(() => {
+    // should emit
     state.set('', 1);
     state.set('a', 1);
     state.set('a.b', 1);
+    // should not emit
     state.set('c.d', 1);
   });
   return Observable
@@ -62,11 +64,14 @@ test('event emit', t => {
 });
 
 test('event emit with cursor', t => {
-  t.plan(3);
+  t.plan(4);
   const state = new State();
   process.nextTick(() => {
+    // should emit
     state.set('', 1);
     state.set('a', 1);
+    state.cursor('a').set('c', 1);
+    // should not emit
     state.set('a.b', 1);
     state.set('c.d', 1);
   });


### PR DESCRIPTION
相比较`dataton`的区别：

- 更少的接口支持，只支持`get`与`set`，`state.load(xxx)`请使用`state.set(xxx)`替代
- 支持`cursor`链式调用和`state`、`cursor`同构。其实是上一个PR的内容：https://github.com/nofluxjs/state/pull/1
- 提供事件监听接口`listen`。不同的是，`listen`返回的是`Observable`，对其进行标准的`subscribe`和`unsubscribe`即可实现监听与取消。
- 支持`change`事件的部分监听，这也是重构`dataton`最重要的功能之一。因为调研后类似实现较少，目前依赖`EventEmitter2`的`namespace`实现。 相关讨论：https://github.com/nofluxjs/state/issues/2

未实现：

- 暂未实现`update`接口，原因是现在的实现对`set`的`value`是无感知的，即使有循环引用、函数等也不需要额外处理，但要实现`update`接口则必须进行深拷贝，要处理这些问题。
- 没有diff检查，无法区分修改是否真的造成了变动。原理同上。
- 因为缺少`load`、`mergeUpdate`等方法，批量修改会多次触发`change`事件，暂未解决。
- 待实现`push`、`pop`等无副作用方法