### PR TITLE
remove rxjs for code size

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
     "eslint": "^3.19.0",
     "eslint-config-airbnb-base": "^11.1.2",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-watch": "^3.0.1",
-    "rxjs": "^5.3.0"
+    "eslint-watch": "^3.0.1"
   },
   "dependencies": {
     "eventemitter2": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
     "eslint": "^3.19.0",
     "eslint-config-airbnb-base": "^11.1.2",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-watch": "^3.0.1"
+    "eslint-watch": "^3.0.1",
+    "rxjs": "^5.3.0"
   },
   "dependencies": {
-    "eventemitter2": "^4.1.0",
-    "rxjs": "^5.3.0"
+    "eventemitter2": "^4.1.0"
   }
 }

--- a/src/state.js
+++ b/src/state.js
@@ -1,6 +1,4 @@
 import { EventEmitter2 } from 'eventemitter2';
-import { Observable } from 'rxjs/Observable';
-import { fromEvent } from 'rxjs/observable/fromEvent';
 import Store from './store';
 import { normalizePath } from './utils';
 
@@ -57,16 +55,31 @@ export default class State {
     });
   }
 
-  listen(message) {
-    let generatedMessage;
+  __generateEventMessage(message) {
     switch (message) {
       case 'change':
-        generatedMessage = ['change', ...this.__cursor, '**'];
-        break;
+        return ['change', ...this.__cursor, '**'];
       default:
-        generatedMessage = message;
-        break;
+        return message;
     }
-    return Observable::fromEvent(this.__emitter, generatedMessage);
+  }
+
+  on(message, callback) {
+    const generatedMessage = this.__generateEventMessage(message);
+    this.__emitter.on(generatedMessage, callback);
+    // return cleanup handler
+    return () => {
+      this.__emitter.off(generatedMessage, callback);
+    };
+  }
+  addEventListener(message, callback) {
+    return this.on(message, callback);
+  }
+  off(message, callback) {
+    const generatedMessage = this.__generateEventMessage(message);
+    this.__emitter.off(generatedMessage, callback);
+  }
+  removeEventListener(message, callback) {
+    return this.off(message, callback);
   }
 }

--- a/test/state.js
+++ b/test/state.js
@@ -45,7 +45,7 @@ test('cursor set', t => {
   t.deepEqual(state.get(), { a: { b: { c: { d: 1, e: 2 } } } });
 });
 
-test.cb('event emit', t => {
+test.cb('event listen and cancel', t => {
   t.plan(4);
   const state = new State();
   const handler = state.on('change', () => t.pass());
@@ -56,6 +56,24 @@ test.cb('event emit', t => {
   state.set('c.d', 1);
   // remove listener
   handler();
+  state.set('', 1);
+  setTimeout(() => {
+    t.end();
+  }, TEST_TIMEOUT);
+});
+
+test.cb('event listen and off', t => {
+  t.plan(4);
+  const state = new State();
+  const callback = () => t.pass();
+  state.on('change', callback);
+  // should emit
+  state.set('', 1);
+  state.set('a', 1);
+  state.set('a.b', 1);
+  state.set('c.d', 1);
+  // remove listener
+  state.off('change', callback);
   state.set('', 1);
   setTimeout(() => {
     t.end();

--- a/test/state.js
+++ b/test/state.js
@@ -57,7 +57,7 @@ test('event emit', t => {
     state.set('c.d', 1);
   });
   return Observable
-    .from(state.listen('change'))
+    .fromEvent(state, 'change')
     .map(() => t.pass())
     .timeoutWith(OBSERVABLE_TIMEOUT, Observable.empty());
 });
@@ -75,7 +75,7 @@ test('event emit with cursor', t => {
     state.set('c.d', 1);
   });
   return Observable
-    .from(state.cursor('a').listen('change'))
+    .fromEvent(state.cursor('a'), 'change')
     .map(() => t.pass())
     .timeoutWith(OBSERVABLE_TIMEOUT, Observable.empty());
 });
@@ -95,7 +95,7 @@ test('set path with dot', t => {
     state.set(['a.e', 'f'], 1);
   });
   return Observable
-    .from(state.cursor('a').listen('change'))
+    .fromEvent(state.cursor('a'), 'change')
     .map(() => t.pass())
     .timeoutWith(OBSERVABLE_TIMEOUT, Observable.empty());
 });
@@ -113,7 +113,7 @@ test('listen path with dot', t => {
     state.set('a.b', 1);
   });
   return Observable
-    .from(state.cursor(['a.b']).listen('change'))
+    .fromEvent(state.cursor(['a.b']), 'change')
     .map(() => t.pass())
     .timeoutWith(OBSERVABLE_TIMEOUT, Observable.empty());
 });


### PR DESCRIPTION
As you can see here https://github.com/nofluxjs/noflux-react/pull/6 . The `rxjs` cost another quarter of bundle file size but `@noflux/state` just use it for event handler. 

Breaking change: I refact the event implement and now `state` provide `on`, `off`, `addEventListener` and `removeEventListener`.

Recommend usage:

```js
// listen
const handler = state.cursor('a').on('change', () => t.pass());
// cancel
handler();
```

or
```js
// listen
const callback = () => t.pass();
const handler = state.cursor('a').on('change', callback);
// cancel
state.cursor('a').off('change', callback);
```