### PR TITLE
add immutable Array operators

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -110,38 +110,37 @@ export default class State {
   }
 
   // immutable Array operators
-  __arrayOperator(subPath, operator, values) {
-    const cursor = this.cursor(subPath);
-    const array = arrayFromAllowNullOrUndefined(cursor.get());
+  __arrayOperator(operator, values) {
+    const array = arrayFromAllowNullOrUndefined(this.get());
     Array.prototype[operator].apply(array, values);
-    cursor.set(array);
+    this.set(array);
   }
 
-  push(subPath, ...values) {
-    this.__arrayOperator(subPath, 'push', values);
+  push(...values) {
+    this.__arrayOperator('push', values);
   }
 
-  pop(subPath) {
-    this.__arrayOperator(subPath, 'pop');
+  pop() {
+    this.__arrayOperator('pop');
   }
 
-  unshift(subPath, ...values) {
-    this.__arrayOperator(subPath, 'unshift', values);
+  unshift(...values) {
+    this.__arrayOperator('unshift', values);
   }
 
-  shift(subPath) {
-    this.__arrayOperator(subPath, 'shift');
+  shift() {
+    this.__arrayOperator('shift');
   }
 
-  fill(subPath, value) {
-    this.__arrayOperator(subPath, 'fill', [value]);
+  fill(value) {
+    this.__arrayOperator('fill', [value]);
   }
 
-  reverse(subPath) {
-    this.__arrayOperator(subPath, 'reverse');
+  reverse() {
+    this.__arrayOperator('reverse');
   }
 
-  splice(subPath, ...values) {
-    this.__arrayOperator(subPath, 'splice', values);
+  splice(...values) {
+    this.__arrayOperator('splice', values);
   }
 }

--- a/src/state.js
+++ b/src/state.js
@@ -1,6 +1,6 @@
 import { EventEmitter2 } from 'eventemitter2';
 import Store from './store';
-import { normalizePath } from './utils';
+import { normalizePath, arrayFromAllowNullOrUndefined } from './utils';
 
 export default class State {
 
@@ -81,5 +81,41 @@ export default class State {
   }
   removeEventListener(message, callback) {
     return this.off(message, callback);
+  }
+
+  // immutable Array operators
+  __arrayOperator(subPath, operator, values) {
+    const cursor = this.cursor(subPath);
+    const array = arrayFromAllowNullOrUndefined(cursor.get());
+    Array.prototype[operator].apply(array, values);
+    cursor.set(array);
+  }
+
+  push(subPath, ...values) {
+    this.__arrayOperator(subPath, 'push', values);
+  }
+
+  pop(subPath) {
+    this.__arrayOperator(subPath, 'pop');
+  }
+
+  unshift(subPath, ...values) {
+    this.__arrayOperator(subPath, 'unshift', values);
+  }
+
+  shift(subPath) {
+    this.__arrayOperator(subPath, 'shift');
+  }
+
+  fill(subPath, value) {
+    this.__arrayOperator(subPath, 'fill', [value]);
+  }
+
+  reverse(subPath) {
+    this.__arrayOperator(subPath, 'reverse');
+  }
+
+  splice(subPath, ...values) {
+    this.__arrayOperator(subPath, 'splice', values);
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,15 +7,15 @@ export const normalizePath = path => {
   throw Error(`State.prototype.cursor only accept string or array, ${typeof path} is forbidden`);
 };
 
-// only null and undefined has no properties
-// ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/No_properties
-export const hasNoProperties = obj => obj === undefined || obj === null;
+export const isNullOrUndefined = obj => obj === undefined || obj === null;
 
 export const getByPath = (obj, path) => {
   let pointer = obj;
   for (let i = 0; i < path.length; i++) {
     const next = path[i];
-    if (hasNoProperties(pointer)) {
+    // only null and undefined has no properties
+    // ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/No_properties
+    if (isNullOrUndefined(pointer)) {
       return undefined;
     }
     pointer = pointer[next];
@@ -48,14 +48,14 @@ export const setByPath = (obj = {}, path = [], value) => {
   const newObj = shallowClone(obj);
   let parentPointer = newObj;
   let lastNext = first;
-  let pointer = hasNoProperties(obj) ? null : obj[first];
+  let pointer = isNullOrUndefined(obj) ? null : obj[first];
 
   for (let i = 0; i < rest.length; i++) {
     const next = rest[i];
     parentPointer[lastNext] = shallowClone(pointer, next);
     parentPointer = parentPointer[lastNext];
     lastNext = next;
-    if (hasNoProperties(pointer)) {
+    if (isNullOrUndefined(pointer)) {
       // always skip traversing null or undefined
       pointer = null;
     } else {
@@ -65,3 +65,9 @@ export const setByPath = (obj = {}, path = [], value) => {
   parentPointer[lastNext] = value;
   return newObj;
 };
+
+// null or undefined will cause an error
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from
+export const arrayFromAllowNullOrUndefined = arrayLike => (
+  isNullOrUndefined(arrayLike) ? [] : [...arrayLike]
+);

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,19 +39,19 @@ export const shallowClone = (obj, path = '') => {
   }
 };
 
-export const setByPath = (obj = {}, path = [], value) => {
+const HEAD = 'HEAD';
+export const setByPath = (obj, path = [], value) => {
   if (!path.length) {
     return value;
   }
-  const [first, ...rest] = path;
 
-  const newObj = shallowClone(obj);
-  let parentPointer = newObj;
-  let lastNext = first;
-  let pointer = isNullOrUndefined(obj) ? null : obj[first];
-
-  for (let i = 0; i < rest.length; i++) {
-    const next = rest[i];
+  const root = {};
+  root[HEAD] = obj;
+  let parentPointer = root;
+  let lastNext = HEAD;
+  let pointer = obj;
+  for (let i = 0; i < path.length; i++) {
+    const next = path[i];
     parentPointer[lastNext] = shallowClone(pointer, next);
     parentPointer = parentPointer[lastNext];
     lastNext = next;
@@ -63,7 +63,7 @@ export const setByPath = (obj = {}, path = [], value) => {
     }
   }
   parentPointer[lastNext] = value;
-  return newObj;
+  return root[HEAD];
 };
 
 // null or undefined will cause an error

--- a/test/state.js
+++ b/test/state.js
@@ -129,3 +129,25 @@ test.cb('listen path with dot', t => {
     t.end();
   }, TEST_TIMEOUT);
 });
+
+test('immutable Array operators', t => {
+  const state = new State();
+  state.set({
+    array: [1, 2, 3],
+  });
+  t.deepEqual(state.get('array'), [1, 2, 3]);
+  state.push('array', 4, 5);
+  t.deepEqual(state.get('array'), [1, 2, 3, 4, 5]);
+  state.pop('array');
+  t.deepEqual(state.get('array'), [1, 2, 3, 4]);
+  state.unshift('array', -1, 0);
+  t.deepEqual(state.get('array'), [-1, 0, 1, 2, 3, 4]);
+  state.shift('array');
+  t.deepEqual(state.get('array'), [0, 1, 2, 3, 4]);
+  state.reverse('array');
+  t.deepEqual(state.get('array'), [4, 3, 2, 1, 0]);
+  state.splice('array', 2, 1, 'a');
+  t.deepEqual(state.get('array'), [4, 3, 'a', 1, 0]);
+  state.fill('array', 0);
+  t.deepEqual(state.get('array'), [0, 0, 0, 0, 0]);
+});

--- a/test/state.js
+++ b/test/state.js
@@ -159,24 +159,40 @@ test('snapshot data', t => {
   t.is(state.canRedo(), false);
 });
 
-test('immutable Array operators', t => {
+test('Array operators worked', t => {
   const state = new State();
   state.set({
     array: [1, 2, 3],
   });
-  t.deepEqual(state.get('array'), [1, 2, 3]);
-  state.push('array', 4, 5);
-  t.deepEqual(state.get('array'), [1, 2, 3, 4, 5]);
-  state.pop('array');
-  t.deepEqual(state.get('array'), [1, 2, 3, 4]);
-  state.unshift('array', -1, 0);
-  t.deepEqual(state.get('array'), [-1, 0, 1, 2, 3, 4]);
-  state.shift('array');
-  t.deepEqual(state.get('array'), [0, 1, 2, 3, 4]);
-  state.reverse('array');
-  t.deepEqual(state.get('array'), [4, 3, 2, 1, 0]);
-  state.splice('array', 2, 1, 'a');
-  t.deepEqual(state.get('array'), [4, 3, 'a', 1, 0]);
-  state.fill('array', 0);
-  t.deepEqual(state.get('array'), [0, 0, 0, 0, 0]);
+  const cursor = state.cursor('array');
+  t.deepEqual(cursor.get(), [1, 2, 3]);
+  cursor.push(4, 5);
+  t.deepEqual(cursor.get(), [1, 2, 3, 4, 5]);
+  cursor.pop();
+  t.deepEqual(cursor.get(), [1, 2, 3, 4]);
+  cursor.unshift(-1, 0);
+  t.deepEqual(cursor.get(), [-1, 0, 1, 2, 3, 4]);
+  cursor.shift();
+  t.deepEqual(cursor.get(), [0, 1, 2, 3, 4]);
+  cursor.reverse();
+  t.deepEqual(cursor.get(), [4, 3, 2, 1, 0]);
+  cursor.splice(2, 1, 'a');
+  t.deepEqual(cursor.get(), [4, 3, 'a', 1, 0]);
+  cursor.fill(0);
+  t.deepEqual(cursor.get(), [0, 0, 0, 0, 0]);
+});
+
+test('Array operatoers create shallow clone', t => {
+  const state = new State();
+  state.set({
+    array: [1, 2, { data: 3 }],
+  });
+  const cursor = state.cursor('array');
+  const data1 = cursor.get();
+  cursor.push(4, 5);
+  const data2 = cursor.get();
+  t.not(data1, data2);
+  // shallow
+  data1[2].data = 33;
+  t.is(data2[2].data, 33);
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,11 @@
 import test from 'ava';
-import { normalizePath, hasNoProperties, getByPath, setByPath } from '../src/utils';
+import {
+  normalizePath,
+  isNullOrUndefined,
+  getByPath,
+  setByPath,
+  arrayFromAllowNullOrUndefined,
+} from '../src/utils';
 
 const deepClone = x => JSON.parse(JSON.stringify(x));
 
@@ -12,12 +18,12 @@ test('normalizePath', t => {
   t.throws(() => normalizePath(null));
 });
 
-test('hasNoProperties', t => {
-  t.is(hasNoProperties(null), true);
-  t.is(hasNoProperties(undefined), true);
-  t.is(hasNoProperties(NaN), false);
-  t.is(hasNoProperties(false), false);
-  t.is(hasNoProperties(0), false);
+test('isNullOrUndefined', t => {
+  t.is(isNullOrUndefined(null), true);
+  t.is(isNullOrUndefined(undefined), true);
+  t.is(isNullOrUndefined(NaN), false);
+  t.is(isNullOrUndefined(false), false);
+  t.is(isNullOrUndefined(0), false);
 });
 
 test('getByPath', t => {
@@ -122,4 +128,11 @@ test('setByPath auto detect by path', t => {
 
   cloneObj.b = [undefined, undefined, { c: 3 }];
   t.deepEqual(newObj, cloneObj);
+});
+
+test('arrayFromAllowNullOrUndefined works', t => {
+  t.deepEqual(arrayFromAllowNullOrUndefined(null), []);
+  t.deepEqual(arrayFromAllowNullOrUndefined(undefined), []);
+  t.deepEqual(arrayFromAllowNullOrUndefined(0), []);
+  t.deepEqual(arrayFromAllowNullOrUndefined({}), []);
 });


### PR DESCRIPTION
Immutable `Array` operators is for less code in `on-` callback arrow functions.
In `dataton` they are `Array.prototype.xfunctions` https://github.com/ssnau/dataton/blob/master/index.js#L394-L409

```jsx
// before
<button
  onClick={() => state.set('todos', (state.get('todos') || []).concat(this.state.inputValue))}
>Add</button>

// or
<button
  onClick={() => {
    const array = state.get('todos') || [];
    // shallow clone
    const newArray = Array.from(array);
    newArray.push(this.state.inputValue);
    state.set('todos', newArray)
  }}
>Add</button>

// after
<button
  onClick={() => state.push('todos', this.state.inputValue)}
>Add</button>
```
Because the operators use `Array.from` to shallow clone the old array, `object`, `string` and other non-array variables will be conveyed to `[]` . (as also as `null` and `undefined`)

There are still 2 problem to resolve.

1. Should `state` support immutable prototype like `concat`, `indexOf` or `map` ?
```js
state.get('array').concat([1, 2, 3]);
// or
state.concat('array', [1,2,3]); // this won't change state
```

2. All `Array` operators must have the first argument `subPath` while `state.get` and `state.set` don't need that may make user confused. What about to make `subPath` required for `get` and `set`?
```js
console.log(state.get(''));
const cursor = state.cursor('a');
cursor.set('', 'value');
```